### PR TITLE
A few minor tweaks

### DIFF
--- a/gl-translator.scm
+++ b/gl-translator.scm
@@ -19,7 +19,7 @@
     ("APIENTRY " . "")
     ("\n}\n" . "")
     ("#include.*\n" . "")
-    ("#define GL_VERSION.*\n" . "")
+    ("#define GL_VERSION_.*\n" . "")
     ("#define GL_ES_VERSION.*\n" . "")
     ("#define [^G].*\n" . "")
     ((: "*const*") . "**")

--- a/opengl-glew.scm
+++ b/opengl-glew.scm
@@ -22,6 +22,15 @@
     (gles (error "is-supported? is not suported with GL ES"))
     (else ((foreign-lambda bool "glewIsSupported" c-string) str))))
 
+(let ((pointer->string (foreign-lambda* c-string ((c-pointer p))
+                         "C_return((char*) p);"))
+      (%get-string get-string)
+      (%get-stringi get-stringi))
+  (set! get-string
+    (lambda (n) (pointer->string (%get-string n))))
+  (set! get-stringi
+    (lambda (n i) (pointer->string (%get-stringi n i)))))
+
 (define init
   (cond-expand
    (gles (lambda () #f))


### PR DESCRIPTION
The GL_VERSION enum value was erased by gl-translator (it’s not a macro variable used in #ifdefs). 

Also, the get-string procedure returned a pointer which isn’t very useful.
